### PR TITLE
feat(fastapi): try to determine codeinfra for agglo intersections

### DIFF
--- a/fastapi/app/algorithm/diagnostic.py
+++ b/fastapi/app/algorithm/diagnostic.py
@@ -1,6 +1,6 @@
 import copy
 
-from .modules import (get_land_score_from_sources, get_air_score_from_sources, get_classification_warning, get_zones_from_intersections)
+from .modules import (get_land_score_from_sources, get_air_score_from_sources, group_intersections_by_identifier, get_classification_warning, get_zones_from_intersections)
 from .tools import (filter_land_intersections_by_codeinfra, filter_soundclassification_by_codeinfra, get_filtered_land_intersections, get_sound_equivalents, default_diagnostic)
 
 
@@ -62,8 +62,14 @@ def get_parcelle_diagnostic(noisemap_intersections, soundclassification_intersec
     # Return air intersections
     diagnostic['air_intersections'] = peb_intersections
 
-    # Return max db lden
+    # Utils
     land_intersections_ld_cbs_A = [x for x in diagnostic['land_intersections_ld'] if x.get('cbstype') == 'A']
+    land_intersections_ln_cbs_A = [x for x in diagnostic['land_intersections_ln'] if x.get('cbstype') == 'A']
+    grouped_ld = group_intersections_by_identifier(land_intersections_ld_cbs_A)
+    grouped_ln = group_intersections_by_identifier(land_intersections_ln_cbs_A)
+    distinct_typesources = list(dict.fromkeys(s.lstrip()[0] for s in grouped_ld if s.strip()))
+
+    # Return max db lden
     all_sources = land_intersections_ld_cbs_A + diagnostic['air_intersections']
     diagnostic['max_db_lden'] = max(
         all_sources,
@@ -84,10 +90,10 @@ def get_parcelle_diagnostic(noisemap_intersections, soundclassification_intersec
     diagnostic["zones"] = get_zones_from_intersections(diagnostic['land_intersections_ld']) if populate.zones else []
 
     # Flags
-    diagnostic['flags']['isMultiExposedSources'] = ((1 if len(filter_land_intersections_by_codeinfra(land_intersections_ld_cbs_A)) > 0 else 0) + (1 if len(diagnostic['air_intersections']) > 0 else 0)) > 1
-    diagnostic['flags']['isMultiExposedLandSources'] = len(filter_land_intersections_by_codeinfra(land_intersections_ld_cbs_A)) > 1
-    diagnostic['flags']['isMultiExposedLandDistinctTypeSources'] = len({i.get('typesource') for i in diagnostic['land_intersections_ld'] if i.get('typesource')}) > 1
-    diagnostic['flags']['isMultiExposedLdenLn'] = (1 if len(diagnostic['land_intersections_ld']) > 0 else 0) + (1 if len(diagnostic['land_intersections_ln']) > 0 else 0) > 1
+    diagnostic['flags']['isMultiExposedSources'] = ((1 if len(grouped_ld) > 0 else 0) + (1 if len(diagnostic['air_intersections']) > 0 else 0)) > 1
+    diagnostic['flags']['isMultiExposedLandSources'] = len(grouped_ld) > 1
+    diagnostic['flags']['isMultiExposedLandDistinctTypeSources'] = len(distinct_typesources) > 1
+    diagnostic['flags']['isMultiExposedLdenLn'] = (1 if len(grouped_ld) > 0 else 0) + (1 if len(grouped_ln) > 0 else 0) > 1
     diagnostic['flags']['isPriorityZone'] = any(item.get('cbstype') == "C" for item in noisemap_intersections)
     diagnostic['flags']['hasClassificationWarning'] = get_classification_warning(noisemap_intersections, soundclassification_intersections)
 

--- a/fastapi/app/algorithm/modules/score_land_transport.py
+++ b/fastapi/app/algorithm/modules/score_land_transport.py
@@ -1,6 +1,7 @@
 import yaml
 from pathlib import Path
 from collections import defaultdict
+from ..tools import DIRECTION_PRIORITIES
 
 
 def load_config():
@@ -64,13 +65,53 @@ def compute_aggregated_score_for_intersections(intersections, levels, all_inters
     ])
 
 
+def find_similar_intersections(item, intersections):
+    """
+    Return intersections that:
+      - have a non-null codeinfra
+      - have the same typesource
+      - have a direction equal to, +45°, or -45° vs the given item
+      - have a legende within ±5 of the item's legende
+    Ordered by closeness: 0° first, then ±45°.
+    """
+    item_dir = item.get("direction")
+    item_legende = item.get("legende")
+    item_typesource = item.get("typesource")
+
+    priority_map = DIRECTION_PRIORITIES.get(item_dir, {})
+
+    candidates = [
+        other for other in intersections
+        if other.get("codeinfra") not in (None, "")
+        and other.get("typesource") == item_typesource
+        and other.get("direction") in priority_map
+        and other.get("legende") is not None
+        and abs(other.get("legende") - item_legende) <= 5
+    ]
+
+    return sorted(candidates, key=lambda x: priority_map[x["direction"]])
+
+
+def determine_codeinfra(item, intersections):
+
+    if item['codeinfra'] is not None:
+        return item['codeinfra']
+
+    similar = find_similar_intersections(item, intersections)
+
+    if len(similar):
+        return similar[0].get('codeinfra')
+
+    return 'NONE'
+
+
 def group_intersections_by_identifier(intersections):
     """
     Groups intersections by a unique identifier based on the (typesource, codeinfra) pair.
     """
     grouped = defaultdict(list)
     for item in intersections:
-        identifier = f"{item['typesource']}_{item['codeinfra']}"
+        identifier = f"INTERSECTIONS_{item['typesource']}_{determine_codeinfra(item, intersections)}"
         grouped[identifier].append(item)
     return grouped
 

--- a/fastapi/app/algorithm/modules/score_land_transport.py
+++ b/fastapi/app/algorithm/modules/score_land_transport.py
@@ -111,7 +111,7 @@ def group_intersections_by_identifier(intersections):
     """
     grouped = defaultdict(list)
     for item in intersections:
-        identifier = f"INTERSECTIONS_{item['typesource']}_{determine_codeinfra(item, intersections)}"
+        identifier = f"{item['typesource']}_INTERSECTIONS_{determine_codeinfra(item, intersections)}"
         grouped[identifier].append(item)
     return grouped
 

--- a/fastapi/app/algorithm/tools.py
+++ b/fastapi/app/algorithm/tools.py
@@ -23,6 +23,18 @@ default_diagnostic = {
     'soundclassification_intersections': [],
 }
 
+DIRECTION_PRIORITIES = {
+    "N":  {"N": 0, "NE": 1, "NW": 1},
+    "NE": {"NE": 0, "N": 1, "E": 1},
+    "E":  {"E": 0, "NE": 1, "SE": 1},
+    "SE": {"SE": 0, "E": 1, "S": 1},
+    "S":  {"S": 0, "SE": 1, "SW": 1},
+    "SW": {"SW": 0, "S": 1, "W": 1},
+    "W":  {"W": 0, "SW": 1, "NW": 1},
+    "NW": {"NW": 0, "W": 1, "N": 1},
+}
+
+
 def get_filtered_land_intersections(noisemap_intersections):
     """
     Get all the filtered arrays needed to calculate score in modules.

--- a/fastapi/tests/unit/score_land_transport/data/lden/score_3_codeinfra_determined_0deg/input.json
+++ b/fastapi/tests/unit/score_land_transport/data/lden/score_3_codeinfra_determined_0deg/input.json
@@ -1,0 +1,28 @@
+{
+  "intersections_agglo": [
+    {
+      "typeterr": "AGGLO",
+      "typesource": "R",
+      "indicetype": "LN",
+      "cbstype": "A",
+      "legende": 55.0,
+      "codeinfra": null,
+      "percent_impacted": 0.1,
+      "direction": "NE"
+    }
+  ],
+  "intersections_infra": [
+    {
+      "typeterr": "INFRA",
+      "typesource": "R",
+      "indicetype": "LD",
+      "cbstype": "A",
+      "legende": 55.0,
+      "codeinfra": "570000",
+      "percent_impacted": 0.09,
+      "direction": "NE"
+    }
+  ],
+  "indicetype": "LD",
+  "expected_score": 3
+}

--- a/fastapi/tests/unit/score_land_transport/data/lden/score_3_codeinfra_determined_45deg/input.json
+++ b/fastapi/tests/unit/score_land_transport/data/lden/score_3_codeinfra_determined_45deg/input.json
@@ -1,0 +1,28 @@
+{
+  "intersections_agglo": [
+    {
+      "typeterr": "AGGLO",
+      "typesource": "R",
+      "indicetype": "LN",
+      "cbstype": "A",
+      "legende": 55.0,
+      "codeinfra": null,
+      "percent_impacted": 0.1,
+      "direction": "N"
+    }
+  ],
+  "intersections_infra": [
+    {
+      "typeterr": "INFRA",
+      "typesource": "R",
+      "indicetype": "LD",
+      "cbstype": "A",
+      "legende": 55.0,
+      "codeinfra": "570000",
+      "percent_impacted": 0.09,
+      "direction": "NE"
+    }
+  ],
+  "indicetype": "LD",
+  "expected_score": 3
+}


### PR DESCRIPTION
Determine codeinfra for AGGLO intersections if : 
* another INFRA intersection is present
* the INFRA intersection cardinality is close (-45deg to +45deg)

In this case the codeinfra of the AGGLO is considered as the codeinfra of the INFRA intersection.

The API still return the original `null` codeinfra of the intersection. The determination is only temporary for the sake of the algorithme precision.