### PR TITLE
fix: afficher une seule noise zone par texte d'alerte unique

### DIFF
--- a/frontend/src/components/diagnostic/regulation/RegulationPlu.tsx
+++ b/frontend/src/components/diagnostic/regulation/RegulationPlu.tsx
@@ -18,9 +18,14 @@ const RegulationPlu = ({ diagnosticItem }: RegulationPluProps) => {
     );
   }
 
+  const uniqueNoisezones = diagnostic.noisezone_intersections.filter(
+    (noisezone, index, self) =>
+      self.findIndex((n) => n.alert === noisezone.alert) === index,
+  );
+
   return (
     <>
-      {diagnostic.noisezone_intersections.map((noisezone, index) => (
+      {uniqueNoisezones.map((noisezone, index) => (
         <div key={index} className={fr.cx("fr-mb-4v")}>
           <DiagnosticRegulationBox
             label={noisezone.label}


### PR DESCRIPTION
## Contexte

Hotfix : sur l'affichage des noise zones du front (PLU), plusieurs zones peuvent partager le même texte d'alerte, créant des doublons visuels.

## Correctif

Déduplication de `noisezone_intersections` par le champ `alert` avant le rendu dans `RegulationPlu.tsx`. Si plusieurs zones ont le même texte `alert`, une seule est affichée.
