### PR TITLE
Feat: unified pipeline runner + dagster job cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,17 @@ was replaced by Dagster assets.
 cd dagster
 uv sync
 
-# Full local end-to-end for dept 033 (needs Box OAuth + AWS creds):
-uv run dg launch --job dev_pipeline_by_codedept_job --partition 033
+# Relaunch pipelines by domain × department (landing-only from S3 by default).
+# Locally you only need one dept — 033 by tradition (the first dept injected):
+uv run python run_pipelines.py --domain all --dept 033          # all dept-scoped domains for 033
+uv run python run_pipelines.py --domain noisemap --dept 033     # one domain for 033
 
-# Landing-only (S3 → PostGIS, no Box; what CI runs):
-PYTHONPATH=src uv run python ci_ingest.py ci_landing_by_codedept_job 033
+# Landing-only CI provisioning (S3 → PostGIS, no Box; what CI runs):
+uv run python ci_ingest.py ci_landing_by_codedept_job 033
 ```
+
+See [`dagster/README.md`](dagster/README.md#relaunching-pipelines) for the full
+relaunch/reset guide (all departments, `--with-launcher`, `--full-refresh`, Scalingo).
 
 ## ⚙️ Dagster + DBT (Orchestration)
 

--- a/dagster/CLAUDE.md
+++ b/dagster/CLAUDE.md
@@ -13,8 +13,11 @@ uv sync                                              # install deps into .venv
 uv run python box_auth.py                            # seed Box OAuth token (one-time)
 uv run dagster dev -p 3001                           # Dagster UI on :3001 (avoids frontend :3000)
 
-# Launch a job from the CLI (dg = dagster-dg-cli)
-uv run dg launch --job dev_pipeline_by_codedept_job --partition 033
+# Relaunch pipelines end-to-end (ingestion + dbt) by domain × dept
+uv run python run_pipelines.py --domain all --dept 033        # see README "Relaunching pipelines"
+
+# Launch a single named ingest job for one partition (dg = dagster-dg-cli)
+uv run dg launch --job agglo_ingest_job --partition 033
 ```
 
 ## Environment Variables
@@ -52,11 +55,24 @@ Trade-off: the picker offers depts a given scope can't materialize — see the `
 all partitions of their landing assets (`AllPartitionMapping()`); they signal downstream dbt that per-dept
 ingest is complete. Their keys match the dbt source names.
 
-**Jobs** (`defs/jobs/defs.py`): per-scope ingest (`agglo_ingest_job`, `infra_ingest_job`,
-`fastline_ingest_job`, `osm_ingest_job`, `peb_ingest_job`, `soundclassification_ingest_job`),
-stage jobs (`full_launcher_job`, `full_landing_job`), domain pipelines (`noisemap_job`, `osm_job`,
-`peb_job`), `dev_pipeline_by_codedept_job` (cross-domain local end-to-end for dept 033,
-includes Box launchers), and `ci_landing_by_codedept_job` (landing-only: S3 → PostGIS + committed fixtures, no
-Box — what CI runs via `ci_ingest.py`).
+**Jobs** (`defs/jobs/defs.py`) are UI convenience handles only: per-scope ingest
+(`agglo_ingest_job`, `infra_ingest_job`, `fastline_ingest_job`, `osm_ingest_job`,
+`peb_ingest_job`, `soundclassification_ingest_job`), stage cross-cuts
+(`full_launcher_job`, `full_landing_job`), and `ci_landing_by_codedept_job`
+(landing-only: S3 → PostGIS + committed fixtures, no Box — what CI runs via `ci_ingest.py`).
+There are intentionally no per-domain "ingest + dbt" jobs.
+
+**Relaunching/resetting** (`run_pipelines.py`): the entrypoint for end-to-end
+relaunches by domain × dept (ingestion + matching dbt). `--domain {all|<domain>}
+--dept {all|<code>}` (both required). Landing-only by default (`--with-launcher`
+for Box), `--full-refresh` for dbt drop+recreate, `--skip-dbt`, `--fail-fast`,
+`--dry-run`. `--dept <code>` runs only dept-scoped domains (noisemap,
+soundclassification, bdnb). Selects assets by group + `stage` tag and runs them via
+the implicit global asset job; multi-unit runs spawn a subprocess per unit. See the
+README "Relaunching pipelines" section.
+
+**Runner scripts**: `run_pipelines.py` (above) for relaunches; `run_job.py` runs one
+named job for one partition (persisted instance, UI-visible); `ci_ingest.py` runs a
+job in an ephemeral instance (CI only).
 
 See `README.md` for the full asset/source/S3-path catalog and ingest internals.

--- a/dagster/README.md
+++ b/dagster/README.md
@@ -148,12 +148,15 @@ Both Dagster and dbt read the connection from env vars (`DB_HOST`/`DB_PORT`/
 `DB_NAME`/`DB_USER`/`DB_PASSWORD`) — there is no connection string in the command.
 A one-off container inherits the app's env; pass `-e` to override/target explicitly:
 
+On Scalingo `uv` is build-only (not on the runtime PATH), so call `python`
+directly — the venv is already active and `dbt` is on PATH:
+
 ```bash
-scalingo --app diag-bruit-dagster run \
+scalingo --app diag-bruit-dagster --region osc-fr1 run \
   -e DB_HOST=<target> -e DB_PORT=<target> -e DB_NAME=<target> \
   -e DB_USER=<target> -e DB_PASSWORD=<target> \
-  --size L \
-  'cd dagster && uv run python run_pipelines.py --domain all --dept all --full-refresh'
+  --size XL \
+  'cd dagster && python run_pipelines.py --domain all --dept all --full-refresh'
 ```
 
 ---

--- a/dagster/README.md
+++ b/dagster/README.md
@@ -68,29 +68,93 @@ token in the `box_tokens` table; it runs via `box_token_refresh_job`, triggered 
 
 ## Jobs
 
-Naming: `<domain>_ingest_job` = ingest assets only (no dbt); bare `<domain>_job` =
-the whole domain incl. downstream dbt models.
+These jobs are convenience handles for launching one ingest scope from the
+**Dagster UI**. For end-to-end relaunches/resets (ingestion + dbt, by domain and
+dept), use [`run_pipelines.py`](#relaunching-pipelines) instead — it selects assets
+dynamically and owns the dbt step, so there are no per-domain "ingest + dbt" jobs.
 
 | Job | Selection |
 |---|---|
-| `full_launcher_job` | every asset tagged `stage=launcher` |
-| `full_landing_job` | every asset tagged `stage=landing` |
+| `full_launcher_job` | every asset tagged `stage=launcher` (all domains) |
+| `full_landing_job` | every asset tagged `stage=landing` (all domains) |
 | `agglo_ingest_job` | `noisemap_agglo` group (launcher + landing) |
 | `infra_ingest_job` | `noisemap_infra` group (launcher + landing) |
 | `fastline_ingest_job` | `noisemap_fastline` group (launcher + landing) |
 | `osm_ingest_job` | `osm` group, ingest stages only |
 | `peb_ingest_job` | `peb` group, ingest stages only |
 | `soundclassification_ingest_job` | `soundclassification` group, ingest stages only |
-| `noisemap_job` | `raw_noisemap` + all upstream (full noisemap ingest, all scopes) |
-| `osm_job` | `noisesource` + all upstream (osm ingest + dbt) |
-| `peb_job` | `peb` mart + all upstream (peb ingest + dbt) |
-| `dev_pipeline_by_codedept_job` | cross-domain local end-to-end for one dept (peb, osm incl. terrasses, soundclassification, bdnb, all noisemap scopes, departements); run with `--partition 033` (uses Box launchers) |
 | `ci_landing_by_codedept_job` | landing-only (no launchers): S3 `_source/` → PostGIS for one dept + the committed `departements` fixture. Needs only AWS creds. Run in CI via `python ci_ingest.py ci_landing_by_codedept_job 033` |
 | `box_token_refresh_job` | `box_token_refresh` (run by the sensor) |
 
-Noisemap ingest is split per source type because each used to carry its own dept
-partition set; run `agglo_ingest_job` / `infra_ingest_job` / `fastline_ingest_job`
-(or `dev_pipeline_by_codedept_job`) for a single dept.
+Run a single named job for one partition from the CLI with
+`uv run python run_job.py <job_name> 033`.
+
+---
+
+## Relaunching pipelines
+
+`run_pipelines.py` is the one entrypoint for relaunching ingestion **and** the
+matching dbt models, parameterised by two axes — domain and department. Both flags
+are **required** (no implicit "everything"), so a full reset must be typed out.
+
+```bash
+uv run python run_pipelines.py --domain <DOMAIN> --dept <DEPT> [flags]
+```
+
+| | `--domain` | `--dept` |
+|---|---|---|
+| values | `all`, `noisemap`, `soundclassification`, `bdnb`, `osm`, `peb`, `noisezone`, `departements` | `all`, or a code like `033` |
+
+The four use cases:
+
+```bash
+# 1. Relaunch every pipeline, every department (full reset)
+uv run python run_pipelines.py --domain all --dept all --full-refresh
+
+# 2. Relaunch one pipeline, every department
+uv run python run_pipelines.py --domain noisemap --dept all
+
+# 3. Relaunch all (dept-scoped) pipelines for one department
+uv run python run_pipelines.py --domain all --dept 033
+
+# 4. Relaunch one pipeline for one department
+uv run python run_pipelines.py --domain noisemap --dept 033
+```
+
+**Department semantics.** A department only exists for the dept-scoped domains
+(`noisemap`, `soundclassification`, `bdnb`). So `--dept <code>` runs *only* those;
+national domains (`osm`, `peb`, `noisezone`, `departements`) are skipped under
+`--domain all` and rejected if named directly (`--domain peb --dept 033` errors —
+use `--dept all`). A dept absent from a domain's registry is a no-op skip.
+
+**Flags.**
+
+| Flag | Effect |
+|---|---|
+| `--with-launcher` | also run the Box launcher stage (Box → S3). Default is landing-only (S3 → PostGIS): no Box, reprocesses existing source. |
+| `--full-refresh` | pass `--full-refresh` to dbt (drop & recreate). Use after a DB wipe. |
+| `--skip-dbt` | ingestion only, no dbt. |
+| `--fail-fast` | stop at the first failing unit. Default: continue and report a summary at the end. |
+| `--dry-run` | print the plan (units + asset keys + dbt selection) without running anything. |
+
+Multi-unit runs (`--domain all` or `--dept all`) spawn one **subprocess per unit**
+for fault isolation, then run the domain-scoped dbt **once**. Runs use the
+configured DagsterInstance, so they appear in the Dagster UI. If any ingestion unit
+fails, dbt is skipped (fix the units and rerun, or rerun dbt manually).
+
+### On Scalingo (target a specific database)
+
+Both Dagster and dbt read the connection from env vars (`DB_HOST`/`DB_PORT`/
+`DB_NAME`/`DB_USER`/`DB_PASSWORD`) — there is no connection string in the command.
+A one-off container inherits the app's env; pass `-e` to override/target explicitly:
+
+```bash
+scalingo --app diag-bruit-dagster run \
+  -e DB_HOST=<target> -e DB_PORT=<target> -e DB_NAME=<target> \
+  -e DB_USER=<target> -e DB_PASSWORD=<target> \
+  --size L \
+  'cd dagster && uv run python run_pipelines.py --domain all --dept all --full-refresh'
+```
 
 ---
 

--- a/dagster/run_job.py
+++ b/dagster/run_job.py
@@ -9,7 +9,10 @@ it is safe to invoke from a one-off `scalingo run` container:
 
     scalingo --app diag-bruit-dagster run \
         -e DB_HOST=<target> -e DB_NAME=<target> ... \
-        python run_job.py noisemap_job 033
+        python run_job.py agglo_ingest_job 033
+
+For relaunching a whole domain (or everything) end-to-end including dbt, prefer
+run_pipelines.py — this script runs a single named job for one partition.
 """
 
 import sys

--- a/dagster/run_pipelines.py
+++ b/dagster/run_pipelines.py
@@ -1,0 +1,255 @@
+"""Relaunch ingestion pipelines (and their dbt models) by domain and department.
+
+    uv run python run_pipelines.py --domain <DOMAIN> --dept <DEPT> [flags]
+
+Both --domain and --dept are REQUIRED — there is no implicit "everything" default,
+so a full reset must be typed out explicitly (`--domain all --dept all`).
+
+Axes
+----
+--domain   all | noisemap | soundclassification | bdnb | osm | peb | noisezone | departements
+--dept     all | <code>   (e.g. 033)
+
+A department only exists for the dept-scoped domains (noisemap, soundclassification,
+bdnb). Consequently:
+  * `--dept <code>` runs ONLY the dept-scoped domains. National domains are skipped
+    under `--domain all`, and naming one directly (e.g. `--domain peb --dept 033`)
+    is an error.
+  * A `<code>` absent from a domain's partition set is skipped with a log line.
+
+Flags
+-----
+--with-launcher   also run the Box launcher stage (Box -> S3). Default: landing-only
+                  (S3 -> PostGIS), which needs no Box and reprocesses existing source.
+--full-refresh    pass --full-refresh to dbt (drop & recreate). Use after a wipe.
+--skip-dbt        ingestion only, no dbt.
+--fail-fast       stop at the first failing unit. Default: continue and report at end.
+--dry-run         print the plan (units + asset keys + dbt selection) without running.
+
+Mechanics
+---------
+The runner selects assets by `group + stage tag` and materialises them through the
+implicit global asset job (`asset_selection`), one partition at a time. For multi-unit
+runs (`--domain all` or `--dept all`) it spawns one subprocess per unit (fault
+isolation), then runs the domain-scoped dbt once. Runs use the configured
+DagsterInstance, so they appear in the Dagster UI (like run_job.py).
+
+The target database is selected purely by env vars (DB_HOST/DB_PORT/DB_NAME/DB_USER/
+DB_PASSWORD) — on Scalingo, pass them with `-e` on the one-off `scalingo run`.
+See dagster/README.md "Relaunching pipelines" for the full guide.
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from dagster import DagsterInstance
+
+import dagster_project.definitions as definitions_module
+
+_DAGSTER_DIR = Path(__file__).resolve().parent
+
+# Logical domain -> Dagster asset group(s). noisemap fans out to its three scopes,
+# each carrying its own dept partition set.
+DOMAIN_GROUPS = {
+    "noisemap": ["noisemap_agglo", "noisemap_infra", "noisemap_fastline"],
+    "soundclassification": ["soundclassification"],
+    "bdnb": ["bdnb"],
+    "osm": ["osm"],
+    "peb": ["peb"],
+    "noisezone": ["noisezone"],
+    "departements": ["departements"],
+}
+PARTITIONED_DOMAINS = {"noisemap", "soundclassification", "bdnb"}
+NATIONAL_DOMAINS = {"osm", "peb", "noisezone", "departements"}
+ALL_DOMAINS = list(DOMAIN_GROUPS)
+
+# Logical domain -> dbt selector. None = no dbt models (source only).
+DOMAIN_DBT_SELECT = {
+    "noisemap": "noisemap",
+    "soundclassification": "soundclassification",
+    "bdnb": "bdnb",
+    "osm": "osm",
+    "peb": "peb",
+    "noisezone": "noisezone",
+    "departements": None,
+}
+
+
+def _load_defs():
+    d = definitions_module.defs
+    return d() if callable(d) else d
+
+
+def _domain_landing_assets(defs, domain, stages):
+    """[(AssetKey, partitions_def_or_None)] for `domain` whose stage tag is in `stages`."""
+    groups = set(DOMAIN_GROUPS[domain])
+    graph = defs.resolve_asset_graph()
+    out = []
+    for key in graph.get_all_asset_keys():
+        node = graph.get(key)
+        tags = getattr(node, "tags", None) or {}
+        if getattr(node, "group_name", None) in groups and tags.get("stage") in stages:
+            out.append((key, getattr(node, "partitions_def", None)))
+    return out
+
+
+def _domain_partition_keys(defs, domain):
+    keys = set()
+    for _key, pdef in _domain_landing_assets(defs, domain, {"landing"}):
+        if pdef is not None:
+            keys.update(pdef.get_partition_keys())
+    return sorted(keys)
+
+
+def _stages(with_launcher):
+    return {"landing", "launcher"} if with_launcher else {"landing"}
+
+
+# ── leaf execution: one domain, one unit ──────────────────────────────────────
+def run_leaf(defs, domain, dept, with_launcher, dry_run):
+    assets = _domain_landing_assets(defs, domain, _stages(with_launcher))
+    if not assets:
+        print(f"  [skip] domain '{domain}': no matching assets")
+        return True
+
+    if domain in PARTITIONED_DOMAINS:
+        selection = [k for k, pdef in assets if pdef is not None and dept in pdef.get_partition_keys()]
+        if not selection:
+            print(f"  [skip] '{domain}' has no '{dept}' partition")
+            return True
+        partition_key = dept
+    else:
+        selection = [k for k, _pdef in assets]
+        partition_key = None
+
+    label = f"{domain} [{dept}]" + (" +launcher" if with_launcher else "")
+    if dry_run:
+        print(f"  [dry-run] {label}: " + ", ".join(k.to_user_string() for k in selection))
+        return True
+
+    print(f"→ materialising {label} ({len(selection)} assets)…")
+    job = defs.resolve_implicit_global_asset_job_def()
+    result = job.execute_in_process(
+        asset_selection=selection,
+        partition_key=partition_key,
+        instance=DagsterInstance.get(),
+        raise_on_error=False,
+    )
+    if not result.success:
+        print(f"❌ {label} failed:")
+        for event in result.get_step_failure_events():
+            err = getattr(event.event_specific_data, "error", None)
+            print(f"  • {event.step_key}: {err.to_string() if err else '<no error info>'}")
+    return result.success
+
+
+# ── orchestration: expand to units and spawn one subprocess each ──────────────
+def plan_units(defs, domain, dept):
+    """Return [(domain, child_dept)] for a multi-unit run, logging skips."""
+    domains = ALL_DOMAINS if domain == "all" else [domain]
+    units = []
+    for d in domains:
+        if d in PARTITIONED_DOMAINS:
+            if dept == "all":
+                units.extend((d, k) for k in _domain_partition_keys(defs, d))
+            else:
+                units.append((d, dept))
+        else:  # national
+            if dept == "all":
+                units.append((d, "all"))
+            else:
+                print(f"  [skip] national domain '{d}' (dept-scoped run --dept {dept})")
+    return units
+
+
+def spawn(domain, dept, args):
+    cmd = [sys.executable, str(Path(__file__).name), "--domain", domain, "--dept", dept, "--skip-dbt"]
+    if args.with_launcher:
+        cmd.append("--with-launcher")
+    if args.fail_fast:
+        cmd.append("--fail-fast")
+    if args.dry_run:
+        cmd.append("--dry-run")
+    print(f"→ {domain} [{dept}]")
+    return subprocess.run(cmd, cwd=_DAGSTER_DIR).returncode == 0
+
+
+# ── dbt ───────────────────────────────────────────────────────────────────────
+def run_dbt(domains, full_refresh, dry_run):
+    selects = [DOMAIN_DBT_SELECT[d] for d in domains if DOMAIN_DBT_SELECT.get(d)]
+    if not selects:
+        print("dbt: nothing to build for the selected domain(s); skipping")
+        return True
+    cmd = ["dbt", "run", "--project-dir", "dbt", "--profiles-dir", "dbt", "--select", *sorted(set(selects))]
+    if full_refresh:
+        cmd.append("--full-refresh")
+    if dry_run:
+        print(f"  [dry-run] dbt: {' '.join(cmd)}")
+        return True
+    print(f"→ dbt: {' '.join(cmd)}")
+    return subprocess.run(cmd, cwd=_DAGSTER_DIR).returncode == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Relaunch ingestion pipelines by domain and department.")
+    parser.add_argument("--domain", required=True, choices=["all", *ALL_DOMAINS])
+    parser.add_argument("--dept", required=True, help="'all' or a department code (e.g. 033)")
+    parser.add_argument("--with-launcher", action="store_true", help="also run the Box launcher stage")
+    parser.add_argument("--full-refresh", action="store_true", help="pass --full-refresh to dbt")
+    parser.add_argument("--skip-dbt", action="store_true", help="ingestion only, no dbt")
+    parser.add_argument("--fail-fast", action="store_true", help="stop at the first failing unit")
+    parser.add_argument("--dry-run", action="store_true", help="print the plan without running")
+    args = parser.parse_args()
+
+    if args.domain in NATIONAL_DOMAINS and args.dept != "all":
+        parser.error(
+            f"'{args.domain}' is a national (non-dept) domain — use '--dept all' "
+            f"(or pick a dept-scoped domain: {', '.join(sorted(PARTITIONED_DOMAINS))})"
+        )
+
+    defs = _load_defs()
+
+    # A leaf = single domain, single unit (concrete dept if partitioned, else national).
+    is_leaf = args.domain != "all" and (
+        args.domain in NATIONAL_DOMAINS or args.dept != "all"
+    )
+
+    if is_leaf:
+        ok = run_leaf(defs, args.domain, args.dept, args.with_launcher, args.dry_run)
+        domains_run = [args.domain]
+    else:
+        units = plan_units(defs, args.domain, args.dept)
+        if not units:
+            print("Nothing to run for this domain/dept combination.")
+            return 0
+        results = []
+        for d, dp in units:
+            success = spawn(d, dp, args)
+            results.append((d, dp, success))
+            if not success and args.fail_fast:
+                print("⛔ --fail-fast: stopping after first failure")
+                break
+        failed = [(d, dp) for d, dp, s in results if not s]
+        print("\n── ingestion summary ─────────────────────────")
+        print(f"  units: {len(results)}   ok: {len(results) - len(failed)}   failed: {len(failed)}")
+        for d, dp in failed:
+            print(f"  ❌ {d} [{dp}]")
+        ok = not failed
+        domains_run = sorted({d for d, _dp, _s in results})
+
+    if args.skip_dbt:
+        return 0 if ok else 1
+
+    if not ok:
+        print("\n⚠️  ingestion had failures — skipping dbt. Fix the units above and rerun,")
+        print("   or rerun dbt manually once raw_* is complete.")
+        return 1
+
+    dbt_ok = run_dbt(domains_run, args.full_refresh, args.dry_run)
+    return 0 if dbt_ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dagster/src/dagster_project/defs/assets/bdnb/defs.py
+++ b/dagster/src/dagster_project/defs/assets/bdnb/defs.py
@@ -51,6 +51,7 @@ def _download_box_folder(client, folder_id: str, local_dir) -> dict[str, str]:
     name="bdnb_launcher",
     partitions_def=BDNB_PARTITIONS,
     group_name=GROUP,
+    tags={"stage": "launcher"},
     kinds={"box", "s3"},
 )
 def bdnb_launcher(context: AssetExecutionContext, box: BoxResource):
@@ -110,6 +111,7 @@ def bdnb_launcher(context: AssetExecutionContext, box: BoxResource):
     name="bdnb_landing",
     partitions_def=BDNB_PARTITIONS,
     group_name=GROUP,
+    tags={"stage": "landing"},
     kinds={"s3", "postgres"},
     deps=["bdnb_launcher"],
 )

--- a/dagster/src/dagster_project/defs/assets/defs.py
+++ b/dagster/src/dagster_project/defs/assets/defs.py
@@ -8,7 +8,7 @@ from dagster_project.io.db import db_url
 @asset(
     key="geo_departements",
     group_name="departements",
-    tags={"source": "local"},
+    tags={"source": "local", "stage": "landing"},
     kinds={"postgres"},
 )
 def ingest_departements(context: AssetExecutionContext):

--- a/dagster/src/dagster_project/defs/assets/soundclassification/defs.py
+++ b/dagster/src/dagster_project/defs/assets/soundclassification/defs.py
@@ -15,6 +15,7 @@ from dagster_project.defs.resources.box import BoxResource
     name="soundclassification_launcher",
     partitions_def=SOUNDCLASS_PARTITIONS,
     group_name=GROUP,
+    tags={"stage": "launcher"},
     kinds={"box", "s3"},
 )
 def soundclassification_launcher(context: AssetExecutionContext, box: BoxResource):
@@ -30,6 +31,7 @@ def soundclassification_launcher(context: AssetExecutionContext, box: BoxResourc
     name="soundclassification_landing",
     partitions_def=SOUNDCLASS_PARTITIONS,
     group_name=GROUP,
+    tags={"stage": "landing"},
     kinds={"s3", "postgres"},
     deps=["soundclassification_launcher"],
 )

--- a/dagster/src/dagster_project/defs/jobs/defs.py
+++ b/dagster/src/dagster_project/defs/jobs/defs.py
@@ -1,16 +1,18 @@
 """Job definitions.
 
-Naming convention: `<domain>_[<scope>_]job` where
-  - <domain>  = noisemap | osm | peb | soundclassification | full
-  - <scope>   = optional: `ingest` (ingest assets only, no dbt), `launcher`,
-                `landing`, or a noisemap source-type (`agglo`, `infra`,
-                `fastline`).
-  - bare `<domain>_job` = the whole domain, dbt included.
+These are convenience handles for launching individual ingest scopes from the
+Dagster UI. End-to-end relaunches/resets (ingestion + dbt, by domain and dept)
+go through `run_pipelines.py`, which selects assets dynamically and owns the dbt
+step — so there are intentionally no per-domain "ingest + dbt" jobs here.
+
+Naming convention: `<scope>_ingest_job` ingests one scope (launcher + landing),
+`full_<stage>_job` cross-cuts a stage across every domain, and
+`ci_landing_by_codedept_job` is the landing-only job CI runs.
 
 Noisemap ingest is split per source type (`agglo_ingest_job`, `infra_ingest_job`,
-`fastline_ingest_job`) because each source has its own dept partition set. To
-ingest "all noisemap data for dept 033" run the three jobs with partition 033,
-or select the relevant assets directly from the Assets page.
+`fastline_ingest_job`). All partitioned assets share `ALL_DEPT_PARTITIONS` and
+skip departments absent from their own registry, so a dept that doesn't apply to
+a scope is a no-op, not an error.
 """
 
 from dagster import AssetSelection, define_asset_job
@@ -65,51 +67,6 @@ soundclassification_ingest_job = define_asset_job(
     "soundclassification_ingest_job",
     selection=AssetSelection.groups("soundclassification") & _STAGE_INGEST,
     tags={"domain": "soundclassification", "scope": "ingest"},
-)
-
-# ── Per-domain "everything" (ingest + dbt) ────────────────────────────────
-# noisemap_job spans the 3 source-type partition defs + unpartitioned dbt.
-# Dagster handles this by treating each partitioned asset on its own axis at
-# launch time. For a focused single-source run use the per-source ingest jobs.
-noisemap_job = define_asset_job(
-    "noisemap_job",
-    selection=AssetSelection.assets("noisemap").upstream(),
-    tags={"domain": "noisemap", "scope": "pipeline"},
-)
-osm_job = define_asset_job(
-    "osm_job",
-    selection=AssetSelection.assets("noisesource").upstream(),
-    tags={"domain": "osm", "scope": "pipeline"},
-)
-peb_job = define_asset_job(
-    "peb_job",
-    selection=AssetSelection.assets("peb").upstream(),
-    tags={"domain": "peb", "scope": "pipeline"},
-)
-# Dev pipeline for dept 033: covers all domains for local end-to-end testing.
-# NOTE: only the partitioned groups (noisemap_agglo/infra/fastline, soundclassification)
-# are scoped to the dept passed via --partition. PEB and OSM are unpartitioned and
-# always ingest their full national datasets (all PEB zones, France-wide OSM
-# foods/schools) regardless of partition — so this is "full local end-to-end",
-# not a lightweight 033-only run.
-# All partitioned groups share ALL_DEPT_PARTITIONS so a single --partition 033 flag
-# applies to every partitioned asset in the run.
-dev_pipeline_by_codedept_job = define_asset_job(
-    "dev_pipeline_by_codedept_job",
-    selection=(
-        AssetSelection.groups("peb")
-        | AssetSelection.groups("osm")
-        | AssetSelection.groups("soundclassification")
-        | AssetSelection.groups("noisemap_agglo")
-        | AssetSelection.groups("noisemap_infra")
-        | AssetSelection.groups("noisemap_fastline")
-        | AssetSelection.groups("noisemap")
-        | AssetSelection.groups("noisezone")
-        | AssetSelection.groups("bdnb")
-        | AssetSelection.groups("departements")
-    ),
-    partitions_def=ALL_DEPT_PARTITIONS,
-    tags={"domain": "dev", "scope": "pipeline"},
 )
 
 # Landing-only (no launchers): reads S3 into PostGIS + the committed reference


### PR DESCRIPTION
## What

Adds **`dagster/run_pipelines.py`** — one entrypoint to relaunch ingestion **and** the matching dbt models, parameterised by **domain × department**. Covers the four use cases:

| | all depts | one dept |
|---|---|---|
| **all domains** | `--domain all --dept all` | `--domain all --dept 033` |
| **one domain** | `--domain noisemap --dept all` | `--domain noisemap --dept 033` |

Both flags are **required** — no implicit "everything", so a full reset must be typed out.

## How it works

- Selects assets by **group + `stage` tag** and materialises them through the implicit global asset job (`asset_selection`), one partition at a time.
- Multi-unit runs (`--domain all` / `--dept all`) spawn **one subprocess per unit** (fault isolation), **continue-and-report** (`--fail-fast` to stop), then run **domain-scoped dbt once**. Runs use the configured DagsterInstance → visible in the Dagster UI.
- `--dept <code>` runs **only dept-scoped domains** (noisemap, soundclassification, bdnb). National domains (osm, peb, noisezone, departements) are skipped under `--domain all` and rejected if named directly.
- Flags: `--with-launcher` (Box → S3; default is landing-only from S3), `--full-refresh`, `--skip-dbt`, `--fail-fast`, `--dry-run`.
- Target DB is env-driven (`DB_*`); on Scalingo pass `-e` on the one-off `run`.

## Job cleanup (`defs.py`)

- **Tag** `soundclassification`/`bdnb` launcher+landing and `geo_departements` with `stage=*` — makes the stage dimension uniform and **fixes a latent bug** where `full_launcher_job`/`full_landing_job` silently missed those domains.
- **Delete** redundant ingest+dbt jobs (`noisemap_job`/`osm_job`/`peb_job`) and `dev_pipeline_by_codedept_job` — superseded by `run_pipelines.py`.
- Kept per-scope `*_ingest_job`s + `full_*_job` + `ci_landing_by_codedept_job` as UI launch handles.

## Docs

Root README ingestion section, `dagster/README.md` (new "Relaunching pipelines" section + jobs table), `dagster/CLAUDE.md`.

## Testing

Validated end-to-end via `--dry-run` across all combinations (leaf, fan-out, national-skip, dept-not-in-registry no-op, `--with-launcher`, dbt selection). Definitions load; job inventory and `stage=landing` coverage asserted. Real materialisation requires a live DB + S3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)