### PR TITLE
Fix: cast acoustic_db_value to text before REGEXP_SUBSTR (stg_noisemap)

### DIFF
--- a/dagster/dbt/models/noisemap/staging/stg_noisemap.sql
+++ b/dagster/dbt/models/noisemap/staging/stg_noisemap.sql
@@ -16,14 +16,14 @@ SELECT
     label,
     kind,
     acoustic_noisemap_kind,
-    REGEXP_SUBSTR(acoustic_db_value, '\d{2}') AS acoustic_db_value,
+    REGEXP_SUBSTR(acoustic_db_value::text, '\d{2}') AS acoustic_db_value,
     acoustic_time_range,
     geometry
 
 FROM {{ source('public_workspace', 'raw_noisemap') }}
 WHERE (
-       (acoustic_time_range = 'LN' AND CAST(REGEXP_SUBSTR(acoustic_db_value, '\d{2}') AS INTEGER) >= 50)
-    OR (acoustic_time_range = 'LD' AND CAST(REGEXP_SUBSTR(acoustic_db_value, '\d{2}') AS INTEGER) >= 55)
+       (acoustic_time_range = 'LN' AND CAST(REGEXP_SUBSTR(acoustic_db_value::text, '\d{2}') AS INTEGER) >= 50)
+    OR (acoustic_time_range = 'LD' AND CAST(REGEXP_SUBSTR(acoustic_db_value::text, '\d{2}') AS INTEGER) >= 55)
 )
 {% if is_incremental() and var('codedept', none) is not none %}
   AND LPAD(codedept, 3, '0') = '{{ var("codedept") }}'


### PR DESCRIPTION
## Erreur

`dbt run --select noisemap` plante sur `stg_noisemap` :

```
Database Error in model stg_noisemap
  function regexp_substr(double precision, unknown) does not exist
  LINE 23: REGEXP_SUBSTR(acoustic_db_value, '\d{2}') AS acoustic_db...
```

## Cause

Le type de `raw_noisemap.acoustic_db_value` est **instable** : `to_postgis` infère le type depuis les données du **premier dept qui crée la table**. Selon les valeurs, la colonne ressort en `text` (OK) ou en `double precision` (KO) — et `REGEXP_SUBSTR` n'existe que pour `(text, text)`. L'ajout du dept 013 a fait basculer la colonne en `double`, d'où le plantage qui n'apparaissait pas avant.

## Fix

Cast `acoustic_db_value::text` avant les 3 `REGEXP_SUBSTR` du modèle. Robuste quel que soit le type inféré, et rétro-compatible (`text::text` inchangé).

## Vérifié (PostGIS local)

| entrée | ancienne forme | nouvelle (`::text`) |
|---|---|---|
| `55.0::double` | ❌ erreur (reproduit le bug prod) | `'55'` |
| `'57'::text` | `'57'` | `'57'` |
| `57.5::double` | ❌ | `'57'` |
| `8.0` (1 chiffre) | ❌ | `NULL` (exclu, comportement inchangé) |

## Cause racine (suivi)

La vraie fragilité est l'inférence de type à l'ingestion. Fix plus profond possible : forcer `acoustic_db_value` en texte au moment du landing (potentiellement avec la PR ingestion #103). Ce patch corrige le symptôme de façon sûre et déployable immédiatement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)