### PR TITLE
Fix: store noisemap acoustic_db_value as text + fail landing loudly

### DIFF
--- a/dagster/src/dagster_project/defs/assets/noisemap/_io.py
+++ b/dagster/src/dagster_project/defs/assets/noisemap/_io.py
@@ -318,6 +318,7 @@ def ingest_from_s3_landing(context: AssetExecutionContext, path: str, type: str,
 
     ingested = 0
     skipped = 0
+    failed: list[str] = []
 
     for entry in mapping:
         shp_path = local_dir / entry["name"]
@@ -339,10 +340,21 @@ def ingest_from_s3_landing(context: AssetExecutionContext, path: str, type: str,
         if success:
             ingested += 1
         else:
+            failed.append(entry["name"])
             context.log.error(f"Failed to ingest {entry['name']} → {db_table} (path: {shp_path})")
 
     shutil.rmtree(local_dir)
     context.log.info(f"Cleaned up {local_dir}")
+
+    # Fail loudly: dept rows were already deleted, so any ingest failure leaves
+    # raw_noisemap incomplete. Surface it as a run failure instead of silent success.
+    attempted = ingested + len(failed)
+    if failed:
+        raise RuntimeError(
+            f"{len(failed)}/{attempted} shapefile(s) failed to ingest into "
+            f"{db_table} (dept={dept}): {failed}. raw_noisemap is now incomplete for "
+            f"this dept — check the per-file errors above."
+        )
 
     return MaterializeResult(metadata={
         "files_downloaded": MetadataValue.int(downloaded),

--- a/dagster/src/dagster_project/ingestion/ingest_shapefiles.py
+++ b/dagster/src/dagster_project/ingestion/ingest_shapefiles.py
@@ -138,6 +138,18 @@ def _widen_columns(engine, schema, table_name, gdf, log):
             if existing_types.get(col, "") in ("BIGINT", "INTEGER", "INT", "SMALLINT"):
                 conn.execute(text(f'ALTER TABLE {schema}."{table_name}" ALTER COLUMN "{col}" TYPE DOUBLE PRECISION'))
                 log(f"Upcasted column {col} from {existing_types[col]} to DOUBLE PRECISION")
+        # Widen a numeric acoustic_db_value to TEXT: appending free-text into a numeric
+        # column fails and silently drops every row.
+        if "acoustic_db_value" in gdf.columns:
+            existing_db_type = existing_types.get("acoustic_db_value", "")
+            text_types = ("TEXT", "VARCHAR", "CHARACTER VARYING", "CHAR", "CHARACTER")
+            if existing_db_type and not any(t in existing_db_type for t in text_types):
+                conn.execute(text(
+                    f'ALTER TABLE {schema}."{table_name}" '
+                    f'ALTER COLUMN acoustic_db_value TYPE TEXT '
+                    f'USING acoustic_db_value::text'
+                ))
+                log(f"Converted column acoustic_db_value from {existing_db_type} to TEXT")
         conn.execute(text(
             f"ALTER TABLE {schema}.{table_name} "
             f"ALTER COLUMN geometry TYPE geometry(Geometry,2154) "
@@ -179,6 +191,13 @@ def ingest_shapefile(file_path, table_name, db_url, schema="raw", if_exists="rep
         for col in ("acoustic_category", "acoustic_buffer"):
             if col in gdf.columns:
                 gdf[col] = pd.to_numeric(gdf[col], errors="coerce")
+
+        # acoustic_db_value is free-text (ranges, suffixes, labels) parsed downstream
+        # in dbt, so force it to TEXT here while keeping NaN/None as SQL NULL.
+        if "acoustic_db_value" in gdf.columns:
+            gdf["acoustic_db_value"] = [
+                None if pd.isna(v) else str(v) for v in gdf["acoustic_db_value"]
+            ]
 
         gdf["geometry"] = gdf["geometry"].apply(drop_z)
 


### PR DESCRIPTION
## Problem

Dept 033 noisemap ingestion (`agglo_landing`) failed to ingest **every** agglo shapefile into `public_workspace.raw_noisemap`:

```
invalid input syntax for type double precision: "[68,72](LGV)"
COPY raw_noisemap, line 1, column acoustic_db_value: "[68,72](LGV)"
```

`raw_noisemap.acoustic_db_value` was typed **`double precision`** (inferred from earlier numeric infra/road sources whose values look like `55`). The **agglo** source has heterogeneous free-text values: ranges (`[68,72]`), suffixed ranges (`[68,72](LGV)`), and label-prefixed values (`Lden5559`, `Lnight5054`). Writing those into a `double precision` column failed, so every agglo row for dept 033 was dropped → missing data in `public.noisemap`.

The column is meant to be free text: `dbt/models/noisemap/staging/stg_noisemap.sql` already parses it with `REGEXP_SUBSTR(acoustic_db_value::text, '\d{2}')` (the `::text` cast added in #104). The correct type is **TEXT**.

**Second bug:** despite all shapefiles failing, `agglo_landing` still reported **STEP_SUCCESS**, so the data loss was silent.

## Fix

1. **Coerce `acoustic_db_value` to TEXT at ingestion** (`ingest_shapefiles.py`). Guarded by column presence (only noisemap sources have it). NaN/None are mapped to SQL `NULL` (not the literal `"nan"`).
2. **Self-heal the existing column** (`_widen_columns`). On preprod `raw_noisemap.acoustic_db_value` already exists as `double precision`, and the landing uses `if_exists="append"`. Forcing text in pandas is not enough — the append still fails. Added logic to `ALTER COLUMN acoustic_db_value TYPE TEXT USING acoustic_db_value::text` when the destination column is non-text. No manual migration required; ingestion heals the table on the next run.
3. **Fail loudly** (`noisemap/_io.py` → `ingest_from_s3_landing`). Dept rows are deleted before append, so any ingest failure leaves `raw_noisemap` incomplete. The landing now `raise`s when any shapefile fails (previously an all-failed run still "succeeded"). Per-file error logging is preserved. This covers all noisemap landings (agglo, infra, infra_fastlines), which all route through `ingest_from_s3_landing`.

## Local validation

A throwaway script (not committed) reproduced the prod state and confirmed the fix against local PostGIS (`:5433`):

- Created `acoustic_db_value` as `double precision`, seeded one numeric row.
- Appended a shapefile (via mapping rename, mirroring `rename_agglo`/`rename_infra`) containing `"[68,72](LGV)"`, `"Lden5559"`, `"[71,75]"`, `"55"`, and a `None`, with `if_exists="append"`:
  - (a) no longer errors,
  - (b) column type is now `TEXT`,
  - (c) all rows landed (seed `60` + 5 source rows),
  - (d) `None` stayed SQL `NULL` (no literal `'nan'`/`'None'`).
- Fresh `if_exists="replace"` ingest created `acoustic_db_value` as `TEXT`.

```
Converted column acoustic_db_value from DOUBLE PRECISION to TEXT
column type after append: TEXT
rows: ['55', '60', '[68,72](LGV)', '[71,75]', 'Lden5559', None]
None preserved as SQL NULL, no literal 'nan'/'None'
fresh column type: TEXT
ALL VALIDATION CHECKS PASSED
```

Test table dropped after validation.

## Note on overlap with #103

This branches off `preprod`, which does NOT yet have #103 (the open PR that replaces `gdf.to_postgis(...)` with a chunked `COPY` writer `_copy_gdf_to_postgis` in `ingest_shapefiles.py`). Whichever merges first, the **`acoustic_db_value` text coercion** and the **`_widen_columns` numeric→text healing** must be preserved (and applied to the new `_copy_gdf_to_postgis` path if #103 lands first). The fail-loud logic lives in `noisemap/_io.py` and does not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)