### PR TITLE
Perf: bound ingestion memory via to_postgis chunksize (replaces #103)

### DIFF
--- a/dagster/src/dagster_project/ingestion/ingest_shapefiles.py
+++ b/dagster/src/dagster_project/ingestion/ingest_shapefiles.py
@@ -11,6 +11,13 @@ from dotenv import load_dotenv
 from shapely import transform
 from geoalchemy2 import Geometry
 
+# Insert rows in batches so large departments (e.g. 013) don't build one giant
+# INSERT in memory (the cause of OOM). Bounds peak memory without changing how
+# column types are inferred (to_postgis still samples the full frame).
+# Override with INGEST_CHUNKSIZE.
+INGEST_CHUNKSIZE = int(os.getenv("INGEST_CHUNKSIZE", "50000"))
+
+
 def drop_z(geom):
     return transform(geom, lambda coords: coords, include_z=False)
 
@@ -220,14 +227,14 @@ def ingest_shapefile(file_path, table_name, db_url, schema="raw", if_exists="rep
 
         log(f"Ingesting to {schema}.{table_name} with if_exists={if_exists}")
         try:
-            gdf.to_postgis(table_name, engine, schema=schema, if_exists=if_exists, dtype={"geometry": Geometry(geometry_type="GEOMETRY", srid=2154)})
+            gdf.to_postgis(table_name, engine, schema=schema, if_exists=if_exists, chunksize=INGEST_CHUNKSIZE, dtype={"geometry": Geometry(geometry_type="GEOMETRY", srid=2154)})
         except Exception as create_err:
             # Race condition: another concurrent partition created the table between our
             # existence check and the CREATE TABLE. Retry as a plain append.
             if if_exists == "append" and "already exists" in str(create_err).lower():
                 log("Concurrent table creation detected, retrying as append")
                 _widen_columns(engine, schema, table_name, gdf, log)
-                gdf.to_postgis(table_name, engine, schema=schema, if_exists="append", dtype={"geometry": Geometry(geometry_type="GEOMETRY", srid=2154)})
+                gdf.to_postgis(table_name, engine, schema=schema, if_exists="append", chunksize=INGEST_CHUNKSIZE, dtype={"geometry": Geometry(geometry_type="GEOMETRY", srid=2154)})
             else:
                 raise
 


### PR DESCRIPTION
## Contexte

#103 cherchait à borner la mémoire d'ingestion (OOM sur le dept 013) en remplaçant `gdf.to_postgis(...)` par un `COPY` chunké. Mais ses tests CI échouaient (`test_diag_generate_from_geometries`).

## Cause de l'échec de #103

Le `COPY` de #103 créait la table depuis une **frame vide** (`gdf.iloc[:0].to_postgis(...)`). Or pandas infère le type SQL en **échantillonnant les données** :

```
infer_dtype(full)  = integer  →  bigint / double precision
infer_dtype(empty) = empty    →  text
```

Donc les colonnes `object` numériques de `raw_*` devenaient **`text`** au lieu de `bigint`/`double precision` → les `CAST`/comparaisons dbt en aval changeaient → diagnostic différent → 2 tests d'intégration cassés. La donnée source était identique ; c'est le **schéma** de `raw_*` qui dérivait.

## Le correctif

Garder `gdf.to_postgis(...)` (inférence de type identique à l'existant, depuis la frame **pleine**) et y ajouter simplement **`chunksize=INGEST_CHUNKSIZE`** (défaut 50 000, surchargeable par env). Ça borne le pic mémoire de la même façon que le COPY (le pic venait de l'INSERT unique matérialisant toutes les lignes), **sans** changer les types ni les valeurs.

## Validé en local (PostGIS :5433)

- `to_postgis(chunksize=2)` vs `to_postgis()` → **types identiques** (`bigint`, `double precision`) et même nombre de lignes. `chunksize` n'affecte que le batch d'INSERT, pas le `CREATE TABLE`.
- Compile OK.

## Suite

Remplace **#103** (à fermer). Compatible avec #106 déjà mergé (coercition `acoustic_db_value`→text + `_widen_columns` ALTER + échec bruyant) : ce PR ne touche que les 2 appels `to_postgis`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)