### PR TITLE
Perf: diagnostic quick wins (GIST indexes + cached Transformer)

### DIFF
--- a/dagster/dbt/models/noisezone/marts/noisezone.sql
+++ b/dagster/dbt/models/noisezone/marts/noisezone.sql
@@ -1,5 +1,8 @@
 {{ config(
-    materialized='table'
+    materialized='table',
+    post_hook=[
+      "CREATE INDEX IF NOT EXISTS idx_{{ this.name }}_geometry ON {{ this }} USING GIST (geometry);"
+    ]
 ) }}
 
 SELECT

--- a/dagster/dbt/models/peb/marts/peb.sql
+++ b/dagster/dbt/models/peb/marts/peb.sql
@@ -1,5 +1,8 @@
 {{ config(
-    materialized='table'
+    materialized='table',
+    post_hook=[
+      "CREATE INDEX IF NOT EXISTS idx_{{ this.name }}_geometry ON {{ this }} USING GIST (geometry);"
+    ]
 ) }}
 
 SELECT

--- a/dagster/dbt/models/soundclassification/marts/soundclassification.sql
+++ b/dagster/dbt/models/soundclassification/marts/soundclassification.sql
@@ -1,5 +1,9 @@
 {{ config(
     materialized='table',
+    post_hook=[
+      "CREATE INDEX IF NOT EXISTS idx_{{ this.name }}_geometry ON {{ this }} USING GIST (geometry);",
+      "CREATE INDEX IF NOT EXISTS idx_{{ this.name }}_road_geometry ON {{ this }} USING GIST (road_geometry);"
+    ]
 ) }}
 
 SELECT

--- a/fastapi/app/utils/geometry.py
+++ b/fastapi/app/utils/geometry.py
@@ -1,3 +1,17 @@
+from functools import lru_cache
+
+import pyproj
+from shapely import wkt
+from shapely.ops import transform
+
+
+@lru_cache(maxsize=None)
+def _utm_transform(epsg: int):
+    """Cache the (4326 -> UTM) Transformer per EPSG zone — France is ~1 zone,
+    so building it once instead of per call avoids the CRS lookup overhead."""
+    return pyproj.Transformer.from_crs("EPSG:4326", f"EPSG:{epsg}", always_xy=True).transform
+
+
 def create_multipolygon_from_coordinates(coordinates) -> str:
     """
     Convert coordinates to WKT MULTIPOLYGON.
@@ -64,15 +78,10 @@ def get_area_m2_from_wkt(polygon_wkt: str) -> float:
     Returns:
         Area in square meters
     """
-    from shapely import wkt
-    from shapely.ops import transform
-    import pyproj
-    
     geom = wkt.loads(polygon_wkt)
     rep = geom.representative_point()
     lon, lat = rep.x, rep.y
     zone = int((lon + 180) // 6) + 1
     epsg = (32600 if lat >= 0 else 32700) + zone
-    project = pyproj.Transformer.from_crs("EPSG:4326", f"EPSG:{epsg}", always_xy=True).transform
-    geom_m = transform(project, geom)
+    geom_m = transform(_utm_transform(epsg), geom)
     return geom_m.area


### PR DESCRIPTION
First of 3 PRs from the diagnostic-perf analysis. Low-risk quick wins.

## Changes
- **peb GIST index** (`models/peb/marts/peb.sql`): `peb` had no index → **seq-scanned on every diagnostic**. Measured locally: `16.8ms → 2.2ms`, `2157 → 2` buffers. Added as a post_hook.
- **soundclassification GIST** on `geometry` **and** `road_geometry` (`ST_Distance`/`ST_ClosestPoint` use the latter): the indexes existed only out-of-band and were **dropped on every `dbt run`** (mart is `materialized='table'`). Now anchored as post_hooks.
- **noisezone GIST** on `geometry`: same vanish-on-rebuild risk → post_hook.
- **`get_area_m2_from_wkt`**: cache the `pyproj.Transformer` per UTM zone (`lru_cache`) + hoist imports — it was rebuilt on every diagnostic.

## Validation (local PostGIS :5433)
- `dbt parse` OK with the new post_hooks.
- Rebuilding `peb` creates `idx_peb_geometry` (`USING gist (geometry)`), 1113 rows.
- `get_area_m2_from_wkt` returns identical area across calls; Transformer cached (`cache_info`: 1 miss / N hits).
- 52 unit tests pass.

Note: `noisezone`/`soundclassification` marts can't fully build locally (raw_* absent), but the post_hooks compile (`dbt parse`) and the mechanism is proven by `peb` + the existing `idx_noisezone_geometry`.

## Of 3
1/3 quick wins (this) · 2/3 noisesource N+1 · 3/3 parallelize queries — split for zero file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)