### PR TITLE
Perf: run the 5 diagnostic queries concurrently (one session each)

### DIFF
--- a/fastapi/app/database.py
+++ b/fastapi/app/database.py
@@ -8,11 +8,15 @@ load_dotenv()
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 
+# Pool sizing: each diagnostic runs its 5 source queries concurrently, one session
+# each (see routes/diag.py), and the diagnostic executor is capped at max_workers=4
+# → up to 4 × 5 = 20 concurrent query sessions, plus the fire-and-forget
+# upsert_diagnostic_result sessions. Size the pool to cover that.
 engine = create_engine(
     DATABASE_URL,
     pool_pre_ping=True,
     pool_recycle=1800,
-    pool_size=5,
+    pool_size=20,
     max_overflow=10,
 )
 

--- a/fastapi/app/routes/diag.py
+++ b/fastapi/app/routes/diag.py
@@ -1,7 +1,5 @@
 import asyncio
-import copy
 import logging
-import time
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from pydantic import BaseModel, Field
@@ -101,48 +99,54 @@ async def process_parcelle(parcelle: ParcelleRequest, populate: Populate):
         return {"parcelle": parcelle, "error": {"status_code": 500, "detail": str(e)}}
 
 
-def _generate_diagnostic_threaded(polygon_wkt: str, codedept: str, populate: Populate):
+def _run_on_own_session(query_fn, *args):
+    """Run one query function on its own Session. A SQLAlchemy Session is not
+    thread-safe, so each concurrent query must get its own."""
     db = SessionLocal()
     try:
-        _t = time.perf_counter()
-        noisemap = query_noisemap_intersecting_features(db, polygon_wkt, codedept)
-
-        _t = time.perf_counter()
-        noisesource = query_noisesource_intersecting_features(db, polygon_wkt, codedept)
-
-        _t = time.perf_counter()
-        noisezone = query_noisezone_intersecting_features(db, polygon_wkt)
-
-        percent_unimpacted = noisemap.get("percent_unimpacted", 0)
-
-        _t = time.perf_counter()
-        sound = query_soundclassification_intersecting_features(db, polygon_wkt, populate.isolation, codedept)
-
-        _t = time.perf_counter()
-        peb = query_peb_intersecting_features(db, polygon_wkt)
-
-        geom_area_m2 = get_area_m2_from_wkt(polygon_wkt) if polygon_wkt else None
-
-        _t = time.perf_counter()
-        result = get_parcelle_diagnostic(
-            noisemap.get('intersections', []),
-            sound.get('intersections', []),
-            peb.get('intersections', []),
-            noisesource.get('intersections', []),
-            noisezone.get('intersections', []),
-            percent_unimpacted,
-            populate,
-            geom_area_m2
-        )
-        return result
+        return query_fn(db, *args)
     finally:
         db.close()
 
 
+def _generate_diagnostic_threaded(polygon_wkt: str, codedept: str, populate: Populate):
+    # The five source queries are independent (only noisemap's percent_unimpacted
+    # and each query's intersections are combined afterward), so run them
+    # concurrently — each on its own session — turning Σ latencies into max.
+    query_args = {
+        "noisemap": (query_noisemap_intersecting_features, polygon_wkt, codedept),
+        "noisesource": (query_noisesource_intersecting_features, polygon_wkt, codedept),
+        "noisezone": (query_noisezone_intersecting_features, polygon_wkt),
+        "sound": (query_soundclassification_intersecting_features, polygon_wkt, populate.isolation, codedept),
+        "peb": (query_peb_intersecting_features, polygon_wkt),
+    }
+    with ThreadPoolExecutor(max_workers=len(query_args)) as pool:
+        futures = {name: pool.submit(_run_on_own_session, fn, *args)
+                   for name, (fn, *args) in query_args.items()}
+        # .result() re-raises any query exception (preserves fail-on-error behavior).
+        results = {name: fut.result() for name, fut in futures.items()}
+
+    noisemap = results["noisemap"]
+    percent_unimpacted = noisemap.get("percent_unimpacted", 0)
+    geom_area_m2 = get_area_m2_from_wkt(polygon_wkt) if polygon_wkt else None
+
+    return get_parcelle_diagnostic(
+        noisemap.get('intersections', []),
+        results["sound"].get('intersections', []),
+        results["peb"].get('intersections', []),
+        results["noisesource"].get('intersections', []),
+        results["noisezone"].get('intersections', []),
+        percent_unimpacted,
+        populate,
+        geom_area_m2
+    )
+
+
 async def generate_diagnostic_async(polygon_wkt: str, codedept: str, populate: Populate):
     loop = asyncio.get_running_loop()
-    diagnostic = await loop.run_in_executor(executor, _generate_diagnostic_threaded, polygon_wkt, codedept, populate)
-    return copy.deepcopy(diagnostic)
+    # get_parcelle_diagnostic already returns a fresh deep-copied template, so no
+    # extra copy is needed here.
+    return await loop.run_in_executor(executor, _generate_diagnostic_threaded, polygon_wkt, codedept, populate)
 
 
 @router.post("/generate/from-parcelles")


### PR DESCRIPTION
3rd of 3 PRs from the diagnostic-perf analysis.

## Problem
`_generate_diagnostic_threaded` (`routes/diag.py`) ran the five source queries (noisemap, noisesource, noisezone, soundclassification, peb) **sequentially on one Session** → latency = Σ of all five. They share no data (only `noisemap.percent_unimpacted` and each query's intersections are combined afterward in `get_parcelle_diagnostic`).

## Fix
- Run the five queries **concurrently** via a `ThreadPoolExecutor`, **each on its own `Session`** (a SQLAlchemy Session is not thread-safe). `fut.result()` re-raises, so any query error still fails the diagnostic exactly as before. Wall-clock → ~max instead of sum.
- Remove the redundant `copy.deepcopy(diagnostic)` in `generate_diagnostic_async` — the result is already a fresh deep-copied template (`algorithm/diagnostic.py:13`).
- Remove the dead `_t = time.perf_counter()` lines (never read) and the now-unused `copy`/`time` imports.
- **Pool sizing** (`database.py`): bump `pool_size` 5→20 — 4 executor workers × 5 concurrent sessions = 20, plus the fire-and-forget `upsert_diagnostic_result` sessions. Documented inline.

## Validation
A/B against `origin/preprod`: ran a **real dept-033 diagnostic** (noisemap 873k + peb with real data; noisezone/soundclassification/noisesource empty) both ways → **byte-identical** result (60768 bytes), no session/thread errors. 52 unit tests pass.

Caveat: only noisemap+peb carry real local data, so the *magnitude* of the speedup (and the heavy `isolation=true` path) wasn't load-tested locally; the equivalence and thread-safety are verified.

## Of 3
1/3 #109 (quick wins) · 2/3 #110 (noisesource N+1) · 3/3 this. Zero file overlap (this touches only `diag.py` + `database.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)