### PR TITLE
Fix: match bdnb code_depar regardless of leading-zero format

### DIFF
--- a/fastapi/app/utils/sig.py
+++ b/fastapi/app/utils/sig.py
@@ -99,9 +99,9 @@ def intersecting_triangle_groups_cte(triangles_cte: CTE, bdnb_table, valid_col="
     ]
 
     if codedept is not None:
-        codedept_no_leading_zero = codedept.lstrip('0') if codedept.lstrip('0') else '0'
+        codedept_variants = {codedept, codedept.lstrip('0') or '0', codedept.zfill(3)}
         conditions.append(
-            (bdnb_table.code_depar == codedept_no_leading_zero)
+            bdnb_table.code_depar.in_(list(codedept_variants))
         )
 
     tri_hits = (


### PR DESCRIPTION
## Symptom
On **preprod**, the soundclassification **isolation correction returns `(0,0)` for every road**; on **prod** the same parcelle returns real values (e.g. `-9,-9`).

## Cause
`intersecting_triangle_groups_cte` filters BDNB buildings by department after **stripping the leading zero** (`'033' → '33'`). But BDNB is ingested with:
- `code_depar = '033'` on **preprod** (verified: 1 217 900 rows for dept 033),
- `code_depar = '33'` on **prod**.

So on preprod the filter (`= '33'`) matches **zero** buildings → no masking → `angle = 140` → `correction_from_angle(140) = 0` for every road. (Not a code path error — `is_valid_now` is a real boolean; the join just never matches.) Prod's `'33'` happens to match the stripped value, which is why prod works.

## Fix
Match **all** leading-zero variants of the department code (`{'033', '33', …}`) so the filter is format-agnostic. This unblocks preprod **and** protects prod, which would otherwise break the next time its BDNB is re-ingested with the current pipeline (producing `'033'`).

## Validation (local PostGIS)
Seeded `bdnb` with `code_depar = '033'` and `= '33'`; both now yield the expected `-9` correction on a masking scene (previously `'033'` → `0`). 52 unit tests pass. Minimal diff (one condition).

## Note
The root inconsistency is that BDNB ingestion produces different `code_depar` formats across environments — worth standardising at ingestion later, but this consumer-side fix is the safe, immediate solution.