### PR TITLE
Fix: match bdnb code_depar regardless of leading-zero format

### DIFF
--- a/fastapi/app/utils/sig.py
+++ b/fastapi/app/utils/sig.py
@@ -117,8 +117,8 @@ def correction_counts_query(
         func.ST_Intersects(bdnb_table.geometry, triangles.c.geom),
     ]
     if codedept is not None:
-        codedept_no_leading_zero = codedept.lstrip("0") or "0"
-        conditions.append(bdnb_table.code_depar == codedept_no_leading_zero)
+        codedept_variants = {codedept, codedept.lstrip("0") or "0", codedept.zfill(3)}
+        conditions.append(bdnb_table.code_depar.in_(list(codedept_variants)))
 
     hits = (
         select(triangles.c.kind, triangles.c.arm, triangles.c.step)


### PR DESCRIPTION
## Symptom
On **preprod** the soundclassification **isolation correction returns `(0,0)` for every road**; on **prod** the same parcelle returns real values (`-9,-9`).

## Cause
`correction_counts_query` filters BDNB buildings by department after **stripping the leading zero** (`'033' → '33'`). BDNB is ingested with `code_depar = '033'` on preprod (verified, 1.2M rows for dept 033) but `'33'` on prod. So on preprod the filter (`= '33'`) matches **zero** buildings → no masking → `angle = 140` → correction `0` everywhere. Prod's `'33'` matches the stripped value, hence prod works.

## Fix
Match **all** leading-zero variants of the department code (`{'033','33',…}`) so the filter is format-agnostic — unblocks preprod and protects prod (which would break once its BDNB is re-ingested with the current pipeline producing `'033'`).

## Validation (local PostGIS)
On the current (post-isolation-perf) code path, seeding `bdnb` with `code_depar` `'033'` and `'33'` both now yield `-9` (previously `'033'` → `0`). 52 unit tests pass. One-condition diff.

Supersedes #114 (which patched a function since removed). Root inconsistency (BDNB `code_depar` format differing per environment) is worth standardising at ingestion as a follow-up.