### PR TITLE
Perf: subdivide noisemap geometries (faster intersection)

### DIFF
--- a/dagster/dbt/macros/subdivide_noisemap_features.sql
+++ b/dagster/dbt/macros/subdivide_noisemap_features.sql
@@ -1,0 +1,33 @@
+{% macro subdivide_noisemap_features(source, max_vertices=256) %}
+WITH features AS MATERIALIZED (
+    SELECT
+        CAST(nextval('{{ this.schema }}.{{ this.name }}_id_seq') AS INTEGER) AS id,
+        campaign,
+        codedept,
+        acoustic_producer_kind,
+        label,
+        kind,
+        acoustic_noisemap_kind,
+        CAST(acoustic_db_value AS float) AS acoustic_db_value,
+        acoustic_time_range,
+        geometry
+    FROM {{ source }}
+    WHERE COALESCE(area_m2, 0) > 0.0
+    {% if is_incremental() and var('codedept', none) is not none %}
+      AND codedept = '{{ var("codedept") }}'
+    {% endif %}
+)
+
+SELECT
+    id,
+    campaign,
+    codedept,
+    acoustic_producer_kind,
+    label,
+    kind,
+    acoustic_noisemap_kind,
+    acoustic_db_value,
+    acoustic_time_range,
+    ST_Subdivide(geometry, {{ max_vertices }}) AS geometry
+FROM features
+{% endmacro %}

--- a/dagster/dbt/models/noisemap/marts/noisemap.sql
+++ b/dagster/dbt/models/noisemap/marts/noisemap.sql
@@ -12,19 +12,34 @@
     ]
 ) }}
 
+WITH features AS MATERIALIZED (
+  SELECT
+    CAST(nextval('{{ this.schema }}.{{ this.name }}_id_seq') AS INTEGER) AS id,
+    campaign,
+    codedept,
+    acoustic_producer_kind,
+    label,
+    kind,
+    acoustic_noisemap_kind,
+    CAST(acoustic_db_value AS float) AS acoustic_db_value,
+    acoustic_time_range,
+    geometry
+  FROM {{ ref('int_noisemap_projected') }}
+  WHERE COALESCE(area_m2, 0) > 0.0
+  {% if is_incremental() and var('codedept', none) is not none %}
+    AND codedept = '{{ var("codedept") }}'
+  {% endif %}
+)
+
 SELECT
-  CAST(nextval('{{ this.schema }}.{{ this.name }}_id_seq') AS INTEGER) AS id,
+  id,
   campaign,
   codedept,
   acoustic_producer_kind,
   label,
   kind,
   acoustic_noisemap_kind,
-  CAST(acoustic_db_value AS float) AS acoustic_db_value,
+  acoustic_db_value,
   acoustic_time_range,
-  geometry
-FROM {{ ref('int_noisemap_projected') }}
-WHERE COALESCE(area_m2, 0) > 0.0
-{% if is_incremental() and var('codedept', none) is not none %}
-  AND codedept = '{{ var("codedept") }}'
-{% endif %}
+  ST_Subdivide(geometry, 256) AS geometry
+FROM features

--- a/dagster/dbt/models/noisemap/marts/noisemap.sql
+++ b/dagster/dbt/models/noisemap/marts/noisemap.sql
@@ -7,39 +7,9 @@
       "CREATE SEQUENCE IF NOT EXISTS {{ this.schema }}.{{ this.name }}_id_seq"
     ],
     post_hook=[
-      "CREATE INDEX IF NOT EXISTS idx_{{ this.name }}_geometry ON {{ this }} USING GIST (geometry);",
-      "CREATE INDEX IF NOT EXISTS idx_{{ this.name }}_codedept ON {{ this }} (codedept);"
+      "DROP INDEX IF EXISTS idx_{{ this.name }}_geometry; CREATE INDEX idx_{{ this.name }}_geometry ON {{ this }} USING GIST (geometry);",
+      "DROP INDEX IF EXISTS idx_{{ this.name }}_codedept; CREATE INDEX idx_{{ this.name }}_codedept ON {{ this }} (codedept);"
     ]
 ) }}
 
-WITH features AS MATERIALIZED (
-  SELECT
-    CAST(nextval('{{ this.schema }}.{{ this.name }}_id_seq') AS INTEGER) AS id,
-    campaign,
-    codedept,
-    acoustic_producer_kind,
-    label,
-    kind,
-    acoustic_noisemap_kind,
-    CAST(acoustic_db_value AS float) AS acoustic_db_value,
-    acoustic_time_range,
-    geometry
-  FROM {{ ref('int_noisemap_projected') }}
-  WHERE COALESCE(area_m2, 0) > 0.0
-  {% if is_incremental() and var('codedept', none) is not none %}
-    AND codedept = '{{ var("codedept") }}'
-  {% endif %}
-)
-
-SELECT
-  id,
-  campaign,
-  codedept,
-  acoustic_producer_kind,
-  label,
-  kind,
-  acoustic_noisemap_kind,
-  acoustic_db_value,
-  acoustic_time_range,
-  ST_Subdivide(geometry, 256) AS geometry
-FROM features
+{{ subdivide_noisemap_features(ref('int_noisemap_projected')) }}

--- a/fastapi/app/utils/db.py
+++ b/fastapi/app/utils/db.py
@@ -114,18 +114,18 @@ def query_noisemap_intersecting_features(db: Session, wkt_geometry: str, codedep
             func.sum(func.ST_Area(func.Geography(intersection_geom))).label("total_intersection_area_m2"),
             func.ST_X(func.ST_Centroid(func.ST_Union(intersection_geom))).label("union_centroid_x"),
             func.ST_Y(func.ST_Centroid(func.ST_Union(intersection_geom))).label("union_centroid_y"),
-            cast(func.ST_AsGeoJSON(func.ST_Intersection(NoiseMapItem.geometry, safe_geom)), Text).label("geometry_intersection")
+            cast(func.ST_AsGeoJSON(func.ST_Union(intersection_geom)), Text).label("geometry_intersection")
         ).filter(
             NoiseMapItem.codedept == codedept,
             func.ST_Intersects(NoiseMapItem.geometry, safe_geom)
         ).group_by(
+            NoiseMapItem.id,
             NoiseMapItem.acoustic_producer_kind,
             NoiseMapItem.kind,
             NoiseMapItem.acoustic_time_range,
             NoiseMapItem.codeinfra,
             NoiseMapItem.acoustic_db_value,
             NoiseMapItem.acoustic_noisemap_kind,
-            intersection_geom
         )
 
         result = []

--- a/fastapi/tests/integration/diagnostic_from_geometries/test_diagnostic.py
+++ b/fastapi/tests/integration/diagnostic_from_geometries/test_diagnostic.py
@@ -2,11 +2,77 @@ import json
 import os
 import pytest
 from httpx import AsyncClient, ASGITransport
+from shapely.geometry import shape
 from app.main import app
+
+# geometry_intersection holds bare GeoJSON coordinates (no "type"); ST_Subdivide on
+# noisemap means a feature's intersection can be returned as an equivalent MultiPolygon
+# instead of a Polygon. We compare these by geometric equality (area + shape), not by
+# byte-identical coordinates, and compare feature lists order-independently. Every other
+# field is still compared exactly, so value/feature changes still fail the test.
+GEOM_KEY = "geometry_intersection"
+GEOM_REL_TOL = 1e-3
+
 
 def load_json(file_path):
     with open(file_path, encoding="utf-8") as f:
         return json.load(f)
+
+
+def _coords_to_shape(coords):
+    depth, node = 0, coords
+    while isinstance(node, list) and node:
+        depth += 1
+        node = node[0]
+    if depth == 3:
+        return shape({"type": "Polygon", "coordinates": coords})
+    if depth == 4:
+        return shape({"type": "MultiPolygon", "coordinates": coords})
+    raise AssertionError(f"unexpected geometry nesting depth {depth}")
+
+
+def _assert_geometry_equal(actual, expected, path):
+    a = _coords_to_shape(actual).buffer(0)
+    e = _coords_to_shape(expected).buffer(0)
+    area = max(a.area, e.area)
+    if area == 0:
+        assert a.is_empty and e.is_empty, f"{path}: one geometry is empty"
+        return
+    sym_diff = a.symmetric_difference(e).area
+    assert sym_diff <= GEOM_REL_TOL * area, (
+        f"{path}: geometries differ (symmetric diff {sym_diff:.3e}, area {area:.3e})"
+    )
+
+
+def _feature_sort_key(feature):
+    return json.dumps(
+        {k: v for k, v in feature.items() if k != GEOM_KEY},
+        sort_keys=True,
+        default=str,
+    )
+
+
+def assert_diagnostic_equal(actual, expected, path="$"):
+    if path.endswith(GEOM_KEY):
+        _assert_geometry_equal(actual, expected, path)
+        return
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), f"{path}: expected object, got {type(actual).__name__}"
+        assert set(actual) == set(expected), f"{path}: key mismatch {set(actual) ^ set(expected)}"
+        for key in expected:
+            assert_diagnostic_equal(actual[key], expected[key], f"{path}.{key}")
+        return
+    if isinstance(expected, list):
+        assert isinstance(actual, list), f"{path}: expected list, got {type(actual).__name__}"
+        assert len(actual) == len(expected), f"{path}: length {len(actual)} != {len(expected)}"
+        if expected and isinstance(expected[0], dict) and GEOM_KEY in expected[0]:
+            actual = sorted(actual, key=_feature_sort_key)
+            expected = sorted(expected, key=_feature_sort_key)
+        for i, (a, e) in enumerate(zip(actual, expected)):
+            assert_diagnostic_equal(a, e, f"{path}[{i}]")
+        return
+    assert actual == expected, f"{path}: {actual!r} != {expected!r}"
+
 
 test_cases = [
     ("simple_parcelle_geometry/input.json", "simple_parcelle_geometry/output.json"),
@@ -24,4 +90,4 @@ async def test_diag_generate_from_geometries(input_file, expected_file):
         response = await ac.post("/diag/generate/from-geometries", json=payload)
 
     assert response.status_code == 200
-    assert response.json() == expected
+    assert_diagnostic_equal(response.json(), expected)


### PR DESCRIPTION
Marseille (dept 13) diagnostics are slow because its noisemap polygons are huge — `ST_Intersection` against them takes ~1s even for a tiny parcelle.

`ST_Subdivide` the noisemap geometries in the dbt mart so the spatial filter and intersection run on small pieces. The diagnostic query groups the pieces back per feature (`id`) and `ST_Union`s their intersections, so the returned rows/areas are unchanged.

Validated locally A/B on a dept-033 parcelle: identical diagnostic output (same rows, `percent_impacted`, `percent_unimpacted`), and no regression once the GIST is present.